### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,6 @@
 name: PyPI
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/itm8-CDC/django-better-azure-communication-email/security/code-scanning/1](https://github.com/itm8-CDC/django-better-azure-communication-email/security/code-scanning/1)

To fix this issue, you need to add a `permissions:` block to restrict the privileges of the GITHUB_TOKEN for this workflow. The minimal permissions needed are typically `contents: read` unless the workflow performs operations that require additional permissions (such as opening pull requests or writing to repository contents), which is not the case here. The permissions block can be added either at the top level (applies to all jobs), or within the specific job (applies only to that job). For simplicity and clarity, it's best to add `permissions:` at the top level directly under the workflow name (after line 1), so all jobs inherit restricted permissions by default. No new methods, imports, or definitions are required; this is a straightforward YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
