### PR TITLE
chore: add pre-commit ci autoupdate_schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   # General checks and trimmers
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This PR adds `autoupdate_schedule: monthly` to the `ci:` block in `.pre-commit-config.yaml` so that pre-commit.ci auto-updates hooks on a monthly schedule.

_Opened automatically by `fix_precommit_schedule.py`._