### PR TITLE
chore: standardise dependabot cooldown and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR standardises `.github/dependabot.yml`:

- Changes `interval: "weekly"` to `interval: "monthly"`
- Removes `semver-xxx-days` lines from cooldown blocks
- Adds `cooldown: default-days: 7` where missing
- Normalises `default-days` to 7 where it differs

_Opened automatically by `fix_dependabot_schedule.py`._